### PR TITLE
Fix `context.defer` on `play` command

### DIFF
--- a/audio/hybrid_commands.py
+++ b/audio/hybrid_commands.py
@@ -1,6 +1,5 @@
 import re
 from abc import ABC
-from functools import partial
 from pathlib import Path
 from re import Pattern
 from typing import Final, Optional

--- a/audio/hybrid_commands.py
+++ b/audio/hybrid_commands.py
@@ -108,6 +108,7 @@ class HybridCommands(PyLavCogMixin, ABC):
                 )
                 return
             player = await self.lavalink.connect_player(channel=channel, requester=author)
+        await context.defer(ephemeral=True)
 
         queries = [await Query.from_string(qf) for q in query.split("\n") if (qf := q.strip("<>").strip())]
         search_queries = [q for q in queries if q.is_search]


### PR DESCRIPTION
When queuing very large playlists with `/play` the interaction can end up timing out before a response is sent, making the user think that queuing the playlist failed even though it didn't.
This PR adds `context.defer()` after all the checks to give the bot more time to process whatever the input is.