### PR TITLE
Don't allow `[p]connect` on channels the author can't connect to

### DIFF
--- a/audio/hybrid_commands.py
+++ b/audio/hybrid_commands.py
@@ -209,6 +209,18 @@ class HybridCommands(PyLavCogMixin, ABC):
                 ephemeral=True,
             )
             return
+        if not (
+            (permission := actual_channel.permissions_for(context.author)) and permission.connect and permission.view_channel
+        ):
+            await context.send(
+                embed=await context.lavalink.construct_embed(
+                    description=_("You don't have permission to connect to {channel}").format(channel=actual_channel.mention),
+                    messageable=context,
+                ),
+                ephemeral=True,
+            )
+            return
+
         if (player := context.player) is None:
             player = await context.lavalink.connect_player(context.author, channel=actual_channel, self_deaf=True)
         else:

--- a/audio/hybrid_commands.py
+++ b/audio/hybrid_commands.py
@@ -210,11 +210,15 @@ class HybridCommands(PyLavCogMixin, ABC):
             )
             return
         if not (
-            (permission := actual_channel.permissions_for(context.author)) and permission.connect and permission.view_channel
+            (permission := actual_channel.permissions_for(context.author))
+            and permission.connect
+            and permission.view_channel
         ):
             await context.send(
                 embed=await context.lavalink.construct_embed(
-                    description=_("You don't have permission to connect to {channel}").format(channel=actual_channel.mention),
+                    description=_("You don't have permission to connect to {channel}").format(
+                        channel=actual_channel.mention
+                    ),
                     messageable=context,
                 ),
                 ephemeral=True,


### PR DESCRIPTION
Users shouldn't be able to move the bot around channels that they themselves don't have access to.
This PR addresses that by adding an extra check.